### PR TITLE
Update Gems for ruby >= 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll', "~> 1.5.1"
 gem 'kramdown'
+gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
     commander (4.1.6)
       highline (~> 1.6.11)
     fast-stemmer (1.0.2)
-    ffi (1.9.3)
+    ffi (1.9.10)
     highline (1.6.21)
     jekyll (1.5.1)
       classifier (~> 1.3)
@@ -21,7 +21,8 @@ GEM
       redcarpet (~> 2.3.0)
       safe_yaml (~> 1.0)
       toml (~> 0.1.0)
-    kramdown (1.3.3)
+    json (1.8.3)
+    kramdown (1.9.0)
     liquid (2.5.5)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
@@ -30,18 +31,18 @@ GEM
     maruku (0.7.0)
     parslet (1.5.0)
       blankslate (~> 2.0)
-    posix-spawn (0.3.8)
+    posix-spawn (0.3.11)
     pygments.rb (0.5.4)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.1.0)
-    rb-fsevent (0.9.4)
+    rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    rb-kqueue (0.2.3)
+    rb-kqueue (0.2.4)
       ffi (>= 0.5.0)
     redcarpet (2.3.0)
-    safe_yaml (1.0.3)
-    toml (0.1.1)
+    safe_yaml (1.0.4)
+    toml (0.1.2)
       parslet (~> 1.5.0)
     yajl-ruby (1.1.0)
 
@@ -50,4 +51,8 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (~> 1.5.1)
+  json
   kramdown
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
ローカル ( ruby 2.2.2 ) で起動しようとしたらエラーで起動できなかったので調べたら safe_yaml のアップデートで解決しそうだったのでしてみました。

ttps://github.com/dtao/safe_yaml/issues/67

そろそろ ruby 2.3.0 もでますし、2.2.0以上でも動くようにするのはいいことかと思います。
（2.2.2未満で動くかは確認していないです・・・ :angel: ）

ちなみに、出たエラーはこんな感じでした。

```
(git)-[viewport] [2.2.2]
% bundle exec jekyll serve
/Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-4.1.6/lib/commander/runner.rb:385:in `block in require_program': program version required (Commander::Runner::CommandError)
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-4.1.6/lib/commander/runner.rb:384:in `each'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-4.1.6/lib/commander/runner.rb:384:in `require_program'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-4.1.6/lib/commander/runner.rb:52:in `run!'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-4.1.6/lib/commander/delegates.rb:8:in `run!'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/commander-4.1.6/lib/commander/import.rb:10:in `block in <top (required)>'
/Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/safe_yaml-1.0.3/lib/safe_yaml/load.rb:43:in `<module:SafeYAML>': undefined method `tagged_classes' for Psych:Module (NoMethodError)
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/safe_yaml-1.0.3/lib/safe_yaml/load.rb:26:in `<top (required)>'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/safe_yaml-1.0.3/lib/safe_yaml.rb:1:in `require'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/safe_yaml-1.0.3/lib/safe_yaml.rb:1:in `<top (required)>'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/jekyll-1.5.1/lib/jekyll.rb:21:in `require'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/jekyll-1.5.1/lib/jekyll.rb:21:in `<top (required)>'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/jekyll-1.5.1/bin/jekyll:7:in `require'
	from /Users/yuta/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/jekyll-1.5.1/bin/jekyll:7:in `<top (required)>'
	from /Users/yuta/.rbenv/versions/2.2.2/bin/jekyll:23:in `load'
	from /Users/yuta/.rbenv/versions/2.2.2/bin/jekyll:23:in `<main>’
```