### PR TITLE
Fix Jekyll 3.1 incompatibility

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,8 +16,8 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% if page.theme.name and page.theme.name != '' %}
-        {% assign THEME_NAME = page.theme.name %}
+      {% if layout.theme.name and layout.theme.name != '' %}
+        {% assign THEME_NAME = layout.theme.name %}
       {% else %}
         {% assign THEME_NAME = site.JB.theme.name %}
       {% endif %}


### PR DESCRIPTION
Fix this:

```
The page build completed successfully, but returned the following warning:

You are currently using the Jekyll Bootstrap framework which has a known incompatibility with Jekyll v3.1. To fix this incompatibility, change `page.theme.name` in `_includes/JB/setup` to `layout.theme.name`. Your site may not build properly until this change has been applied. For more information, see http://jekyllrb.com/docs/upgrading/2-to-3/#layout-metadata.

For information on troubleshooting Jekyll see:

  https://help.github.com/articles/troubleshooting-jekyll-builds

If you have any questions you can contact us by replying to this email.
```